### PR TITLE
Add EnableSyncOutput property to MiniscopeV4 and MiniCam

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.3.4</VersionPrefix>
+    <VersionPrefix>0.3.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Miniscope/UclaMiniscopeV4.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4.cs
@@ -13,7 +13,6 @@ namespace OpenEphys.Miniscope
     public class UclaMiniscopeV4 : Source<UclaMiniscopeV4Frame>
     {
 
-
         // Frame size
         const int Width = 608;
         const int Height = 608;
@@ -54,9 +53,13 @@ namespace OpenEphys.Miniscope
             "this option is set to true, the LED will not turn on.")]
         public bool LedRespectsTrigger { get; set; } = false;
 
+        [Description("When set to true, the Sync Output pin will toggle when a frame " +
+            "is captured. Otherwise, it will not toggle.")]
+        public bool EnableSyncOutput { get; set; } = true;    
+
         // State
         readonly IObservable<UclaMiniscopeV4Frame> source;
-        readonly object captureLock = new object();
+        readonly object captureLock = new();
         AbusedUvcRegisters originalState;
 
 
@@ -102,13 +105,10 @@ namespace OpenEphys.Miniscope
             capture.SetProperty(CaptureProperty.FrameWidth, Width);
             capture.SetProperty(CaptureProperty.FrameHeight, Height);
 
-            // Start the camera
-            capture.SetProperty(CaptureProperty.Saturation, 1);
-
             return cgs;
         }
 
-        static internal void IssueStopCommands(OpenCV.Net.Capture capture, AbusedUvcRegisters originalState)
+        static internal void IssueStopCommands(Capture capture, AbusedUvcRegisters originalState)
         {
             Helpers.SendConfig(capture, Helpers.CreateCommand(32, 1, 255));
             Helpers.SendConfig(capture, Helpers.CreateCommand(88, 0, 114, 255));
@@ -128,10 +128,10 @@ namespace OpenEphys.Miniscope
                         var lastEWL = Focus;
                         var lastFps = FramesPerSecond;
                         var lastSensorGain = SensorGain;
+                        var lastEnableSyncOutput = EnableSyncOutput;
                         // var lastInterleaveLed = InterleaveLed;
-                        
 
-                        using (var capture = OpenCV.Net.Capture.CreateCameraCapture(Index))
+                        using (var capture = Capture.CreateCameraCapture(Index))
                         {
                             try
                             {
@@ -141,6 +141,12 @@ namespace OpenEphys.Miniscope
                                 {
                                     // Get trigger input state
                                     var gate = capture.GetProperty(CaptureProperty.Gamma) != 0;
+
+                                    if (EnableSyncOutput != lastEnableSyncOutput || !initialized)
+                                    {
+                                        capture.SetProperty(CaptureProperty.Saturation, EnableSyncOutput ? 1.0 : 0.0);
+                                        lastEnableSyncOutput = EnableSyncOutput;
+                                    }
 
                                     if (LedRespectsTrigger)
                                     {


### PR DESCRIPTION
- Fixes #38 
- Allows the user to gate the Sync Output line using internal bonsai logic that can be tied to e.g. start and stop of recording
- This branch is incorrectly named, it should be issue-38

