### PR TITLE
Add timeout to miniscope v4 frame production

### DIFF
--- a/OpenEphys.Miniscope/MiniscopeV4MediaCapture.cs
+++ b/OpenEphys.Miniscope/MiniscopeV4MediaCapture.cs
@@ -18,6 +18,10 @@ namespace OpenEphys.Miniscope
 {
     internal class MiniscopeV4MediaCapture : IDisposable
     {
+        private const string UvcVid = "04B4";
+        private const string UvcPidUsb3 = "00F9";
+        private const string UvcPidUsb2 = "00F8";
+
         public IMiniscopeDaqControls DaqControls { get; }
         public IUvcProcessingUnit ProcessingUnit { get; }
         public Version FwVersion { get; }
@@ -179,7 +183,12 @@ namespace OpenEphys.Miniscope
         public static async Task<IReadOnlyList<string>> GetConnectedMiniscopes()
         {
             var devices = await DeviceInformation.FindAllAsync(DeviceClass.VideoCapture);
-            return devices.Where(d => d.Name.StartsWith("MINISCOPE")).Select(d => d.Id).ToList();
+            return devices.Where(d => 
+                d.Id.IndexOf($"vid_{UvcVid}",StringComparison.OrdinalIgnoreCase) >= 0 &&
+                ( d.Id.IndexOf($"pid_{UvcPidUsb2}", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                  d.Id.IndexOf($"pid_{UvcPidUsb3}", StringComparison.OrdinalIgnoreCase ) >= 0) &&
+                  d.Name.IndexOf("MINISCOPE", StringComparison.InvariantCultureIgnoreCase) >= 0)
+                .Select(d => d.Id).ToList();
         }
 
         static IReadOnlyList<string> cachedDeviceList = null;

--- a/OpenEphys.Miniscope/UclaMiniscopeV4.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4.cs
@@ -27,6 +27,9 @@ namespace OpenEphys.Miniscope
         const int Width = 608;
         const int Height = 608;
 
+        //how many seconds without frames before closing the stream
+        const int FrameTimeoutSeconds = 2;
+
         // 1 quaternion = 2^14 bits
         const float QuatConvFactor = 1.0f / (1 << 14);
 
@@ -126,10 +129,23 @@ namespace OpenEphys.Miniscope
 
         static internal void IssueStopCommands(IMiniscopeDaqControls controls)
         {
-            controls.EnableFrameTTLs(false);
-            controls.I2C.QueueCommand(32, 1, 255);
-            controls.I2C.QueueCommand(88, 0, 114, 255);
-            controls.I2C.CommitCommands();
+            try
+            {
+                controls.EnableFrameTTLs(false);
+                controls.I2C.QueueCommand(32, 1, 255);
+                controls.I2C.QueueCommand(88, 0, 114, 255);
+                controls.I2C.CommitCommands();
+            }
+            catch (InvalidOperationException)
+            {
+                // NB : Is there is a timeout due to a usb disconnection, the
+                // media capture interface can "work" silently, or fail
+                // in any case, we are doing a cleanup here. If it fails
+                // (usually because there is no device anymore)
+                // we just continue with the cleanup
+            }
+
+
         }
 
 
@@ -215,7 +231,11 @@ namespace OpenEphys.Miniscope
                                     }
                                 }
                             }
-                        }).Publish().RefCount();
+                        }).Timeout(TimeSpan.FromSeconds(FrameTimeoutSeconds))
+                        .Catch((TimeoutException e) => {
+                            return Observable.Throw<UclaMiniscopeV4Frame>(new TimeoutException("Frame timeout"));
+                        })
+                        .Publish();
 
                         // Configure device
                         IssueStartCommands(capture.DaqControls);
@@ -227,7 +247,9 @@ namespace OpenEphys.Miniscope
                         // having this limit is not noticeable
                         // We also send a dummy frame to the controls, to set the settings such as FPS before we receive the first frame
                         var throttledFrame = Observable.Return(new UclaMiniscopeV4Frame(null, new Quaternion(), 0, false, false))
-                        .Concat(frameObservable).Sample(new TimeSpan(0, 0, 0, 0, 67)).Publish().RefCount();
+                        .Concat(frameObservable).Sample(new TimeSpan(0, 0, 0, 0, 67))
+                        .Catch(Observable.Empty<UclaMiniscopeV4Frame>()) // NB : ignore exceptions on the control subscriptions. They will be catched downstream by Bonsai
+                        .Publish().RefCount();
                         
                         // Brightness
                         subscriptionList.Add(throttledFrame
@@ -272,6 +294,10 @@ namespace OpenEphys.Miniscope
 
                         // Start acquisition
                         await capture.Start(Width, Height, cancellationToken);
+
+                        // Now start frame distribution, with the timeout starting here
+                        subscriptionList.Add(frameObservable.Connect());
+
                         await Task.Delay(-1, cancellationToken);
 
                     }

--- a/OpenEphys.Miniscope/UclaMiniscopeV4.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4.cs
@@ -7,11 +7,11 @@ using System.Linq;
 using System.Numerics;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Reactive.Concurrency;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Bonsai;
-using Bonsai.Reactive;
 using OpenCV.Net;
 
 namespace OpenEphys.Miniscope
@@ -242,17 +242,17 @@ namespace OpenEphys.Miniscope
 
                         // Prepare hardware controls and connection
 
-                        // NB: This line allows to throttle the uvc control signals, so even if two buffered frames arrived
-                        // to quickly, we limit in time (right now to ~2 frames time). This affects manual controls, so
-                        // having this limit is not noticeable
+                        // NB : We decouple control activation from the main event, but still use frame production as
+                        // a throttle of sorts, and to update led brightness depending on frame triger value
+                        // (to take advantage of batch i2c command transmission, all controls need to be updated on the same block)
                         // We also send a dummy frame to the controls, to set the settings such as FPS before we receive the first frame
-                        var throttledFrame = Observable.Return(new UclaMiniscopeV4Frame(null, new Quaternion(), 0, false, false))
-                        .Concat(frameObservable).Sample(new TimeSpan(0, 0, 0, 0, 67))
+                        var controlsObservable = Observable.Return(new UclaMiniscopeV4Frame(null, new Quaternion(), 0, false, false))
+                        .Concat(frameObservable).ObserveOn(TaskPoolScheduler.Default)
                         .Catch(Observable.Empty<UclaMiniscopeV4Frame>()) // NB : ignore exceptions on the control subscriptions. They will be catched downstream by Bonsai
                         .Publish().RefCount();
                         
                         // Brightness
-                        subscriptionList.Add(throttledFrame
+                        subscriptionList.Add(controlsObservable
                             .Select(c => new { Gate = c.Trigger, RespectsTrigger = LedRespectsTrigger, Brightness = LedBrightness })
                             .DistinctUntilChanged().Select(val =>
                             {
@@ -266,13 +266,13 @@ namespace OpenEphys.Miniscope
 
                         // SensorGain
                         subscriptionList.Add(
-                            throttledFrame.Select(_ => SensorGain).DistinctUntilChanged().Subscribe(val =>
+                            controlsObservable.Select(_ => SensorGain).DistinctUntilChanged().Subscribe(val =>
                             {
                                 capture.DaqControls.I2C.QueueCommand(32, 5, 0, 204, 0, (byte)val);
                             }));
 
                         // Focus
-                        subscriptionList.Add(throttledFrame
+                        subscriptionList.Add(controlsObservable
                             .Select(_ => Focus).DistinctUntilChanged().Subscribe(val =>
                             {
                                 var scaled = val * 1.27;
@@ -280,7 +280,7 @@ namespace OpenEphys.Miniscope
                             }));
 
                         // FPS
-                        subscriptionList.Add(throttledFrame
+                        subscriptionList.Add(controlsObservable
                             .Select(_ => FramesPerSecond).DistinctUntilChanged().Subscribe(val =>
                             {
                                 byte v0 = (byte)((int)val & 0x00000FF);
@@ -288,7 +288,7 @@ namespace OpenEphys.Miniscope
                                 capture.DaqControls.I2C.QueueCommand(32, 5, 0, 201, v0, v1);
                             }));
 
-                        subscriptionList.Add(throttledFrame.Subscribe(_ => capture.DaqControls.I2C.CommitCommands()));
+                        subscriptionList.Add(controlsObservable.Subscribe(_ => capture.DaqControls.I2C.CommitCommands()));
                         subscriptionList.Add(frameObservable.Subscribe(observer));
 
 

--- a/OpenEphys.Miniscope/UclaMiniscopeV4.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4.cs
@@ -204,7 +204,10 @@ namespace OpenEphys.Miniscope
                             }
                             finally
                             {
-                                while (frameChannel.Reader.TryRead(out MiniscopeV4RawFrame pendingFrame))
+                                // NB : Do a non-cancellable asynchronous flush
+                                // This will continue until the channel is marked as completed
+                                // ensuring that no frames can be accidentally added after the flush
+                                await foreach (MiniscopeV4RawFrame pendingFrame in frameChannel.Reader.ReadAllAsync())
                                 {
                                     if (pendingFrame.DataArray != null)
                                     {
@@ -276,6 +279,12 @@ namespace OpenEphys.Miniscope
                     finally
                     {
                         subscriptionList.Dispose();
+
+                        // NB : Close the channel
+                        // This will make the producer stop adding frames to it
+                        // and the consumer can flush them quickly
+                        frameChannel.Writer.TryComplete();
+
                         IssueStopCommands(capture.DaqControls);
                     }
                 }


### PR DESCRIPTION
This adds a timeout, so if there is a device disconnection for any reason, the workflow will stop.
Right now it throws a reactive exception, we could also fail silently

The timeout is for now a fixed constant in seconds. I don't think this should be any exposed value, but we can tweak it as needed.

Also fixed a potential leak on the `ArrayPool` due to a potential race condition.

Note that mediacapture is a bit quirky with disconnections and reconnection. It might be necessary to wait some seconds after a reconnection for the system to be aware of it. The workflow can fail with a variety of errors if started while Windows is configuring the hardware in the background. This does not cause any permanent issue, i.e.: a second attempt once the driver backend is ready will work.

- Fixes #53 