### PR TITLE
Remove MyGet references

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
-    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
-    <add key="Boost Packages" value="https://www.myget.org/F/bonsai-boost/api/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
There was an extra `NuGet.config` which contained the old myget.org package sources. This led to the actions failing. Removing this file should resolve the Actions.