### PR TITLE
Rename trigger and aux inputs to DigitalIn

### DIFF
--- a/OpenEphys.Miniscope/UclaMiniscopeV4.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4.cs
@@ -84,15 +84,15 @@ namespace OpenEphys.Miniscope
         //public bool InterleaveLed { get; set; } = false;
      
         /// <summary>
-        /// Gets or sets a value indicating whether to turn off the LED when the selected digital input is low.
+        /// Gets or sets the digital input that gates the excitation LED.
         /// </summary>
         /// <remarks>
-        /// Note that these pins are low by default. Therefore, if this option is set to
-        /// an undriven input, the LED will not turn on.
+        /// The LED turns on only when the selected input is high. These pins are pulled
+        /// low by default; selecting an undriven input will keep the LED off.
+        /// Set to <see cref="MiniscopeDaqDigitalIn.None"/> to keep the lED on.
         /// </remarks>
-        [Description("Turn off the LED when the selected digital input is low. " +
-            "Note that these pins are low by default. Therefore, if this option is set to" +
-            "an undriven input, the LED will not turn on.")]
+        [Description("The digital input that gates the excitation LED. " +
+            "The LED is only on while the selected input is high.")]
         public MiniscopeDaqDigitalIn LedRespectsDigitalIn { get; set; } = MiniscopeDaqDigitalIn.None;
 
         /// <summary>

--- a/OpenEphys.Miniscope/UclaMiniscopeV4.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4.cs
@@ -84,17 +84,39 @@ namespace OpenEphys.Miniscope
         //[Description("Only turn on excitation LED during camera exposures.")]
         //public bool InterleaveLed { get; set; } = false;
 
+        
         /// <summary>
-        /// Gets or sets a value indicating whether to turn off the LED when the trigger input is low.
+        /// Gets or sets a value indicating whether to turn off the LED when the selected digital input is low.
         /// </summary>
         /// <remarks>
-        /// Note that this pin is low by default. Therefore, if it is not driven and this option is set to
-        /// <see langword="true"/>, the LED will not turn on.
+        /// Note that these pins are low by default. Therefore, if this option is set to
+        /// an undriven input, the LED will not turn on.
         /// </remarks>
-        [Description("Turn off the LED when the trigger input is low. " +
-            "Note that this pin is low by default. Therefore, if it is not driven and " +
-            "this option is set to true, the LED will not turn on.")]
-        public bool LedRespectsTrigger { get; set; } = false;
+        [Description("Turn off the LED when the selected digital input is low. " +
+            "Note that these pins are low by default. Therefore, if this option is set to" +
+            "an undriven input, the LED will not turn on.")]
+        public MiniscopeDaqDigitalIn LedRespectsDigitalIn { get; set; } = MiniscopeDaqDigitalIn.None;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to turn off the LED when the digital input 0 is low.
+        /// </summary>
+        /// <remarks>
+        /// [Obsolete]. Cannot tag this property with the Obsolete attribute due to https://github.com/dotnet/runtime/issues/100453
+        /// This exists to provide a path for old workflows to set a value to <see cref="LedRespectsDigitalIn"/>
+        /// </remarks>
+        [Browsable(false)]
+        [Externalizable(false)]
+        public bool LedRespectsTrigger {
+            get { return LedRespectsDigitalIn != MiniscopeDaqDigitalIn.None; }
+            set { LedRespectsDigitalIn = value ? MiniscopeDaqDigitalIn.DigitalIn0 : MiniscopeDaqDigitalIn.None; }
+        }
+
+        /// <summary>
+        /// Prevents the LedRespectsTrigger property from being serialized
+        /// </summary>
+        /// <returns>false</returns>
+        [Obsolete]
+        public bool ShouldSerializeLedRespectsTrigger() { return false; }
 
         static internal void IssueStartCommands(IMiniscopeDaqControls controls)
         {
@@ -157,9 +179,8 @@ namespace OpenEphys.Miniscope
                 {
                     var rgbImage = new IplImage(image.Size, IplDepth.U8, 3);
                     CV.CvtColor(image, rgbImage, ColorConversion.Yuv2BgrYuy2);
-                    bool trigger = (frameInfo.State & 0x01) != 0;
-                    bool aux = (frameInfo.State & 0x02) != 0;
-                    return new UclaMiniscopeV4Frame(rgbImage, quat, (int)frameInfo.FrameCount,trigger, aux);
+                    MiniscopeDaqDigitalIn digitalIn = (MiniscopeDaqDigitalIn)(frameInfo.State & 0x3);
+                    return new UclaMiniscopeV4Frame(rgbImage, quat, (int)frameInfo.FrameCount,digitalIn);
                 }
             }
         }
@@ -246,7 +267,7 @@ namespace OpenEphys.Miniscope
                         // (to take advantage of batch i2c command transmission, all controls need to be updated on the same block)
                         // We also send a dummy frame to the controls, to set the settings such as FPS before we receive the first frame
                         var controlsObservable = 
-                            Observable.Return(new UclaMiniscopeV4Frame(null, new Quaternion(), 0, false, false))
+                            Observable.Return(new UclaMiniscopeV4Frame(null, new Quaternion(), 0, new MiniscopeDaqDigitalIn()))
                             .Concat(frameObservable)
                             .ObserveOn(TaskPoolScheduler.Default)
                             .Catch(Observable.Empty<UclaMiniscopeV4Frame>()) // NB : ignore exceptions on the control subscriptions. They will be catched downstream by Bonsai
@@ -255,10 +276,10 @@ namespace OpenEphys.Miniscope
                         
                         // Brightness
                         subscriptionList.Add(controlsObservable
-                            .Select(c => new { Gate = c.Trigger, RespectsTrigger = LedRespectsTrigger, Brightness = LedBrightness })
+                            .Select(c => new { LedGate = c.DigitalIn.HasFlag(LedRespectsDigitalIn), Brightness = LedBrightness })
                             .DistinctUntilChanged().Select(val =>
                             {
-                                if (val.RespectsTrigger && !val.Gate) return (byte)255;
+                                if (!val.LedGate) return (byte)255;
                                 return (byte)(255 - 2.55 * val.Brightness);
                             }).DistinctUntilChanged().Subscribe(val =>
                             {

--- a/OpenEphys.Miniscope/UclaMiniscopeV4.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4.cs
@@ -72,7 +72,6 @@ namespace OpenEphys.Miniscope
         [Description("Frames captured per second.")]
         public FrameRateV4 FramesPerSecond { get; set; } = FrameRateV4.Fps30;
 
-
         /// <summary>
         /// Gets the firmware version reported by the connected DAQ.
         /// </summary>
@@ -83,8 +82,7 @@ namespace OpenEphys.Miniscope
         //// TODO: Does not work with DAQ for some reason
         //[Description("Only turn on excitation LED during camera exposures.")]
         //public bool InterleaveLed { get; set; } = false;
-
-        
+     
         /// <summary>
         /// Gets or sets a value indicating whether to turn off the LED when the selected digital input is low.
         /// </summary>
@@ -267,7 +265,7 @@ namespace OpenEphys.Miniscope
                         // (to take advantage of batch i2c command transmission, all controls need to be updated on the same block)
                         // We also send a dummy frame to the controls, to set the settings such as FPS before we receive the first frame
                         var controlsObservable = 
-                            Observable.Return(new UclaMiniscopeV4Frame(null, new Quaternion(), 0, new MiniscopeDaqDigitalIn()))
+                            Observable.Return(new UclaMiniscopeV4Frame(null, new Quaternion(), 0, MiniscopeDaqDigitalIn.None))
                             .Concat(frameObservable)
                             .ObserveOn(TaskPoolScheduler.Default)
                             .Catch(Observable.Empty<UclaMiniscopeV4Frame>()) // NB : ignore exceptions on the control subscriptions. They will be catched downstream by Bonsai
@@ -276,10 +274,14 @@ namespace OpenEphys.Miniscope
                         
                         // Brightness
                         subscriptionList.Add(controlsObservable
-                            .Select(c => new { LedGate = c.DigitalIn.HasFlag(LedRespectsDigitalIn), Brightness = LedBrightness })
+                            .Select(c => new { 
+                                LedGate = LedRespectsDigitalIn != MiniscopeDaqDigitalIn.None && 
+                                !c.DigitalIn.HasFlag(LedRespectsDigitalIn), 
+                                Brightness = LedBrightness 
+                            })
                             .DistinctUntilChanged().Select(val =>
                             {
-                                if (!val.LedGate) return (byte)255;
+                                if (val.LedGate) return (byte)255;
                                 return (byte)(255 - 2.55 * val.Brightness);
                             }).DistinctUntilChanged().Subscribe(val =>
                             {

--- a/OpenEphys.Miniscope/UclaMiniscopeV4.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4.cs
@@ -276,7 +276,7 @@ namespace OpenEphys.Miniscope
                         subscriptionList.Add(controlsObservable
                             .Select(c => new { 
                                 LedGate = LedRespectsDigitalIn != MiniscopeDaqDigitalIn.None && 
-                                !c.DigitalIn.HasFlag(LedRespectsDigitalIn), 
+                                (c.DigitalIn & LedRespectsDigitalIn) == 0, // if any input is 1, do not gate
                                 Brightness = LedBrightness 
                             })
                             .DistinctUntilChanged().Select(val =>

--- a/OpenEphys.Miniscope/UclaMiniscopeV4.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4.cs
@@ -84,15 +84,13 @@ namespace OpenEphys.Miniscope
         //public bool InterleaveLed { get; set; } = false;
      
         /// <summary>
-        /// Gets or sets the digital input that gates the excitation LED.
+        /// Gets or sets whether a digital input controls the LED.
         /// </summary>
         /// <remarks>
-        /// The LED turns on only when the selected input is high. These pins are pulled
-        /// low by default; selecting an undriven input will keep the LED off.
-        /// Set to <see cref="MiniscopeDaqDigitalIn.None"/> to keep the lED on.
+        /// To keep the LED continuously on, set to <see cref="MiniscopeDaqDigitalIn.None"/>. These
+        /// pins are pulled low by default; selecting an undriven input will keep the LED off.
         /// </remarks>
-        [Description("The digital input that gates the excitation LED. " +
-            "The LED is only on while the selected input is high.")]
+        [Description("If a digital input is selected, the LED will only be on while the selected input is high")]
         public MiniscopeDaqDigitalIn LedRespectsDigitalIn { get; set; } = MiniscopeDaqDigitalIn.None;
 
         /// <summary>

--- a/OpenEphys.Miniscope/UclaMiniscopeV4Frame.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4Frame.cs
@@ -4,22 +4,22 @@ using OpenCV.Net;
 
 namespace OpenEphys.Miniscope
 {
-    ///<summary>
-    ///Specifies the state of the DAQ digital input pins.
-    ///</summary>
+    /// <summary>
+    /// Specifies the Miniscope DAQ digital input pins.
+    /// </summary>
     [Flags]
     public enum MiniscopeDaqDigitalIn
     {
         /// <summary>
-        /// Specifies that no digital inputs are high.
+        /// Specifies no digital input pin.
         /// </summary>
         None = 0,
         /// <summary>
-        /// Specifies that digital input 0 is high.
+        /// Specifies digital input 0.
         /// </summary>
         DigitalIn0 = 1,
         /// <summary>
-        /// Specifies that digital input 1 is high.
+        /// Specifies digital input 1.
         /// </summary>
         DigitalIn1 = 2,
     }
@@ -36,7 +36,7 @@ namespace OpenEphys.Miniscope
         /// <param name="image">The captured image.</param>
         /// <param name="quaternion">The head-orientation quaternion from the onboard IMU.</param>
         /// <param name="frameNumber">The hardware frame counter value at the time of capture.</param>
-        /// <param name="digitalIn">The state of the digital inputs at the time of capture.</param>
+        /// <param name="digitalIn">The digital inputs that are high at the time of capture.</param>
         public UclaMiniscopeV4Frame(IplImage image, Quaternion quaternion, int frameNumber, MiniscopeDaqDigitalIn digitalIn)
         {
             FrameNumber = frameNumber;
@@ -61,7 +61,7 @@ namespace OpenEphys.Miniscope
         public Quaternion Quaternion { get; }
 
         /// <summary>
-        /// Gets the state of the digital inputs at the time of capture.
+        /// Gets the digital inputs that are high at the time of capture.
         /// </summary>
         public MiniscopeDaqDigitalIn DigitalIn { get; }
     }

--- a/OpenEphys.Miniscope/UclaMiniscopeV4Frame.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4Frame.cs
@@ -4,7 +4,6 @@ using OpenCV.Net;
 
 namespace OpenEphys.Miniscope
 {
-
     ///<summary>
     ///Specifies the state of the DAQ digital input pins.
     ///</summary>
@@ -37,8 +36,7 @@ namespace OpenEphys.Miniscope
         /// <param name="image">The captured image.</param>
         /// <param name="quaternion">The head-orientation quaternion from the onboard IMU.</param>
         /// <param name="frameNumber">The hardware frame counter value at the time of capture.</param>
-        /// <param name="trigger">The state of the trigger input at the time of capture.</param>
-        /// <param name="aux">The state of the auxiliary digital input at the time of capture.</param>
+        /// <param name="digitalIn">The state of the digital inputs at the time of capture.</param>
         public UclaMiniscopeV4Frame(IplImage image, Quaternion quaternion, int frameNumber, MiniscopeDaqDigitalIn digitalIn)
         {
             FrameNumber = frameNumber;

--- a/OpenEphys.Miniscope/UclaMiniscopeV4Frame.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4Frame.cs
@@ -1,8 +1,30 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 using OpenCV.Net;
 
 namespace OpenEphys.Miniscope
 {
+
+    ///<summary>
+    ///Specifies the state of the DAQ digital input pins.
+    ///</summary>
+    [Flags]
+    public enum MiniscopeDaqDigitalIn
+    {
+        /// <summary>
+        /// Specifies that no digital inputs are high.
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Specifies that digital input 0 is high.
+        /// </summary>
+        DigitalIn0 = 1,
+        /// <summary>
+        /// Specifies that digital input 1 is high.
+        /// </summary>
+        DigitalIn1 = 2,
+    }
+
     /// <summary>
     /// Represents a single frame captured from a UCLA Miniscope V4, including image data,
     /// head-orientation quaternion, and digital I/O state.
@@ -17,13 +39,12 @@ namespace OpenEphys.Miniscope
         /// <param name="frameNumber">The hardware frame counter value at the time of capture.</param>
         /// <param name="trigger">The state of the trigger input at the time of capture.</param>
         /// <param name="aux">The state of the auxiliary digital input at the time of capture.</param>
-        public UclaMiniscopeV4Frame(IplImage image, Quaternion quaternion, int frameNumber, bool trigger, bool aux)
+        public UclaMiniscopeV4Frame(IplImage image, Quaternion quaternion, int frameNumber, MiniscopeDaqDigitalIn digitalIn)
         {
             FrameNumber = frameNumber;
             Image = image;
             Quaternion = quaternion;
-            Trigger = trigger;
-            Aux = aux;
+            DigitalIn = digitalIn;
         }
 
         /// <summary>
@@ -42,13 +63,8 @@ namespace OpenEphys.Miniscope
         public Quaternion Quaternion { get; }
 
         /// <summary>
-        /// Gets the state of the trigger input at the time of capture.
+        /// Gets the state of the digital inputs at the time of capture.
         /// </summary>
-        public bool Trigger { get; }
-
-        /// <summary>
-        /// Gets the state of the auxiliary digital input at the time of capture.
-        /// </summary>
-        public bool Aux { get; }
+        public MiniscopeDaqDigitalIn DigitalIn { get; }
     }
 }


### PR DESCRIPTION
- Created a flag enum
- Replaced aux and trigger frame properties with a DigitalIn enum
- Replaced `LedRespectTrigger` with `LedRespectsDigitalIn`, allowing input selection
- Kept old `LedRespectTrigger` as an obsolete property to load old workflows following [this pattern](https://github.com/open-ephys/bonsai-onix1/blob/2b995c526ffaf4c340bc3fb3faa85b9c7e41eb45/OpenEphys.Onix1/ConfigureNeuropixelsV1f.cs#L43-L59)
- Old workflows using the `trigger` output will load but will not run, it needs to be replaced with a `DigitalIn` with a `HasFlag` to behave the same.
- Fixes #60 

Note: I put the `MiniscopeDaqDigitalIn` enum definition on the `UclaMiniscopeV4Frame.cs` file but probably the proper location would be another. I would appreciate suggestions.