### PR TITLE
Add HardwareTime to UclaMiniscopeV4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Miniscope/UclaMiniscopeV4.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4.cs
@@ -179,7 +179,7 @@ namespace OpenEphys.Miniscope
                     var rgbImage = new IplImage(image.Size, IplDepth.U8, 3);
                     CV.CvtColor(image, rgbImage, ColorConversion.Yuv2BgrYuy2);
                     MiniscopeDaqDigitalIn digitalIn = (MiniscopeDaqDigitalIn)(frameInfo.State & 0x3);
-                    return new UclaMiniscopeV4Frame(rgbImage, quat, (int)frameInfo.FrameCount, digitalIn, frameInfo.Clock);
+                    return new UclaMiniscopeV4Frame(rgbImage, quat, (int)frameInfo.FrameCount, digitalIn, frameInfo.HardwareTime);
                 }
             }
         }
@@ -363,7 +363,7 @@ namespace OpenEphys.Miniscope
         struct FrameInfo
         {
             public uint FrameCount;
-            public uint Clock;
+            public uint HardwareTime;
             public uint State;
         }
 
@@ -380,7 +380,7 @@ namespace OpenEphys.Miniscope
             ulong* src = (ulong*)buffer;
 
             uint w0 = ExtractWord(src[0]); // FrameCount
-            uint w1 = ExtractWord(src[1]); // Clock
+            uint w1 = ExtractWord(src[1]); // HardwareTime
             uint w2 = ExtractWord(src[2]); // State
             uint w3 = ExtractWord(src[3]); // Quaternion: W, X
             uint w4 = ExtractWord(src[4]); // Quaternion: Y, Z
@@ -388,7 +388,7 @@ namespace OpenEphys.Miniscope
             info = new FrameInfo
             {
                 FrameCount = w0,
-                Clock = w1,
+                HardwareTime = w1,
                 State = w2
             };
 

--- a/OpenEphys.Miniscope/UclaMiniscopeV4.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4.cs
@@ -179,7 +179,7 @@ namespace OpenEphys.Miniscope
                     var rgbImage = new IplImage(image.Size, IplDepth.U8, 3);
                     CV.CvtColor(image, rgbImage, ColorConversion.Yuv2BgrYuy2);
                     MiniscopeDaqDigitalIn digitalIn = (MiniscopeDaqDigitalIn)(frameInfo.State & 0x3);
-                    return new UclaMiniscopeV4Frame(rgbImage, quat, (int)frameInfo.FrameCount, digitalIn, frameInfo.FrameTime);
+                    return new UclaMiniscopeV4Frame(rgbImage, quat, (int)frameInfo.FrameCount, digitalIn, frameInfo.Clock);
                 }
             }
         }
@@ -363,7 +363,7 @@ namespace OpenEphys.Miniscope
         struct FrameInfo
         {
             public uint FrameCount;
-            public uint FrameTime;
+            public uint Clock;
             public uint State;
         }
 
@@ -380,7 +380,7 @@ namespace OpenEphys.Miniscope
             ulong* src = (ulong*)buffer;
 
             uint w0 = ExtractWord(src[0]); // FrameCount
-            uint w1 = ExtractWord(src[1]); // FrameTime
+            uint w1 = ExtractWord(src[1]); // Clock
             uint w2 = ExtractWord(src[2]); // State
             uint w3 = ExtractWord(src[3]); // Quaternion: W, X
             uint w4 = ExtractWord(src[4]); // Quaternion: Y, Z
@@ -388,7 +388,7 @@ namespace OpenEphys.Miniscope
             info = new FrameInfo
             {
                 FrameCount = w0,
-                FrameTime = w1,
+                Clock = w1,
                 State = w2
             };
 

--- a/OpenEphys.Miniscope/UclaMiniscopeV4.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4.cs
@@ -179,7 +179,7 @@ namespace OpenEphys.Miniscope
                     var rgbImage = new IplImage(image.Size, IplDepth.U8, 3);
                     CV.CvtColor(image, rgbImage, ColorConversion.Yuv2BgrYuy2);
                     MiniscopeDaqDigitalIn digitalIn = (MiniscopeDaqDigitalIn)(frameInfo.State & 0x3);
-                    return new UclaMiniscopeV4Frame(rgbImage, quat, (int)frameInfo.FrameCount,digitalIn);
+                    return new UclaMiniscopeV4Frame(rgbImage, quat, (int)frameInfo.FrameCount, digitalIn, frameInfo.FrameTime);
                 }
             }
         }
@@ -281,7 +281,7 @@ namespace OpenEphys.Miniscope
                         // (to take advantage of batch i2c command transmission, all controls need to be updated on the same block)
                         // We also send a dummy frame to the controls, to set the settings such as FPS before we receive the first frame
                         var controlsObservable = 
-                            Observable.Return(new UclaMiniscopeV4Frame(null, new Quaternion(), 0, MiniscopeDaqDigitalIn.None))
+                            Observable.Return(new UclaMiniscopeV4Frame(null, new Quaternion(), 0, MiniscopeDaqDigitalIn.None, 0))
                             .Concat(frameObservable)
                             .Catch(Observable.Empty<UclaMiniscopeV4Frame>()) // NB : ignore exceptions on the control subscriptions. They will be catched downstream by Bonsai
                             .ObserveOn(TaskPoolScheduler.Default)
@@ -366,6 +366,7 @@ namespace OpenEphys.Miniscope
             public uint FrameTime;
             public uint State;
         }
+
         private static uint ExtractWord(ulong v)
         {
             return (uint)(((v >> 8) & 0x000000FF) |
@@ -373,6 +374,7 @@ namespace OpenEphys.Miniscope
                           ((v >> 24) & 0x00FF0000) |
                           ((v >> 32) & 0xFF000000));
         }
+
         static unsafe void ExtractMetadata(IntPtr buffer, out FrameInfo info, out Quaternion quat)
         {
             ulong* src = (ulong*)buffer;

--- a/OpenEphys.Miniscope/UclaMiniscopeV4Frame.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4Frame.cs
@@ -37,12 +37,14 @@ namespace OpenEphys.Miniscope
         /// <param name="quaternion">The head-orientation quaternion from the onboard IMU.</param>
         /// <param name="frameNumber">The hardware frame counter value at the time of capture.</param>
         /// <param name="digitalIn">The digital inputs that are high at the time of capture.</param>
-        public UclaMiniscopeV4Frame(IplImage image, Quaternion quaternion, int frameNumber, MiniscopeDaqDigitalIn digitalIn)
+        /// <param name="frameTime">The time of capture in ms.</param>
+        public UclaMiniscopeV4Frame(IplImage image, Quaternion quaternion, int frameNumber, MiniscopeDaqDigitalIn digitalIn, uint frameTime)
         {
             FrameNumber = frameNumber;
             Image = image;
             Quaternion = quaternion;
             DigitalIn = digitalIn;
+            FrameTime = frameTime;
         }
 
         /// <summary>
@@ -64,5 +66,10 @@ namespace OpenEphys.Miniscope
         /// Gets the digital inputs that are high at the time of capture.
         /// </summary>
         public MiniscopeDaqDigitalIn DigitalIn { get; }
+
+        /// <summary>
+        /// Gets the time the frame was captured.
+        /// </summary>
+        public uint FrameTime { get; }
     }
 }

--- a/OpenEphys.Miniscope/UclaMiniscopeV4Frame.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4Frame.cs
@@ -37,14 +37,14 @@ namespace OpenEphys.Miniscope
         /// <param name="quaternion">The head-orientation quaternion from the onboard IMU.</param>
         /// <param name="frameNumber">The hardware frame counter value at the time of capture.</param>
         /// <param name="digitalIn">The digital inputs that are high at the time of capture.</param>
-        /// <param name="frameTime">The time of capture in ms.</param>
-        public UclaMiniscopeV4Frame(IplImage image, Quaternion quaternion, int frameNumber, MiniscopeDaqDigitalIn digitalIn, uint frameTime)
+        /// <param name="clock">The hardware time of the frame, as set by the DAQ.</param>
+        public UclaMiniscopeV4Frame(IplImage image, Quaternion quaternion, int frameNumber, MiniscopeDaqDigitalIn digitalIn, uint clock)
         {
             FrameNumber = frameNumber;
             Image = image;
             Quaternion = quaternion;
             DigitalIn = digitalIn;
-            FrameTime = frameTime;
+            Clock = clock;
         }
 
         /// <summary>
@@ -68,8 +68,12 @@ namespace OpenEphys.Miniscope
         public MiniscopeDaqDigitalIn DigitalIn { get; }
 
         /// <summary>
-        /// Gets the time the frame was captured.
+        /// Gets the hardware timestamp of the frame, in milliseconds.
         /// </summary>
-        public uint FrameTime { get; }
+        /// <remarks>
+        /// Hardware time is set by the DAQ, and captures the relative time of the frame
+        /// since acquisition started.
+        /// </remarks>
+        public uint Clock { get; }
     }
 }

--- a/OpenEphys.Miniscope/UclaMiniscopeV4Frame.cs
+++ b/OpenEphys.Miniscope/UclaMiniscopeV4Frame.cs
@@ -37,14 +37,14 @@ namespace OpenEphys.Miniscope
         /// <param name="quaternion">The head-orientation quaternion from the onboard IMU.</param>
         /// <param name="frameNumber">The hardware frame counter value at the time of capture.</param>
         /// <param name="digitalIn">The digital inputs that are high at the time of capture.</param>
-        /// <param name="clock">The hardware time of the frame, as set by the DAQ.</param>
-        public UclaMiniscopeV4Frame(IplImage image, Quaternion quaternion, int frameNumber, MiniscopeDaqDigitalIn digitalIn, uint clock)
+        /// <param name="hardwareTime">The value of the DAQ's free-running timer at the time of capture.</param>
+        public UclaMiniscopeV4Frame(IplImage image, Quaternion quaternion, int frameNumber, MiniscopeDaqDigitalIn digitalIn, uint hardwareTime)
         {
             FrameNumber = frameNumber;
             Image = image;
             Quaternion = quaternion;
             DigitalIn = digitalIn;
-            Clock = clock;
+            HardwareTime = hardwareTime;
         }
 
         /// <summary>
@@ -68,12 +68,12 @@ namespace OpenEphys.Miniscope
         public MiniscopeDaqDigitalIn DigitalIn { get; }
 
         /// <summary>
-        /// Gets the hardware timestamp of the frame, in milliseconds.
+        /// Gets the hardware time of the frame, in milliseconds.
         /// </summary>
         /// <remarks>
-        /// Hardware time is set by the DAQ, and captures the relative time of the frame
-        /// since acquisition started.
+        /// The DAQ's timer runs independently of acquisition start. This value
+        /// can be used to measure the interval between frames, not as an absolute timestamp.
         /// </remarks>
-        public uint Clock { get; }
+        public uint HardwareTime { get; }
     }
 }


### PR DESCRIPTION
Exposes the frame time as a `uint` property of the `UclaMiniscopeV4` data frame. Unsigned values are in milliseconds.