### PR TITLE
Append WinRT message to media capture failed exception error

### DIFF
--- a/OpenEphys.Miniscope/MiniscopeV4MediaCapture.cs
+++ b/OpenEphys.Miniscope/MiniscopeV4MediaCapture.cs
@@ -141,7 +141,7 @@ namespace OpenEphys.Miniscope
         void OnMediaCaptureFailed(MediaCapture sender, MediaCaptureFailedEventArgs errorEventArgs)
         {
             if (cancellationToken.IsCancellationRequested) return;
-            frameChannel.TryComplete(new IOException("Error acquiring frames"));
+            frameChannel.TryComplete(new IOException($"Error acquiring frames: {errorEventArgs.Message}"));
         }
 
 


### PR DESCRIPTION
Before a `OnMediaCaptureFailed` event only displayed "Error acquring frames"
Now the `errorEventArgs.Message` field is appended